### PR TITLE
Update org-mode-teaser.org

### DIFF
--- a/featureshow/org-mode-teaser.org
+++ b/featureshow/org-mode-teaser.org
@@ -122,7 +122,7 @@ line
 comment
 #+END_COMMENT
 
-*** COMMENT: no exported either
+*** COMMENT no exported either
 
 foo bar
 


### PR DESCRIPTION
Commenting subtrees must begin with `COMMENT`, not `COMMENT:`
